### PR TITLE
enabled requirement for master key in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
+  config.require_master_key = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.


### PR DESCRIPTION
Reverted commit to branch commit #: [hotfix-deploy 0ec04f7](https://github.com/3ninjaneers/judoten/commit/0ec04f7993f07d8b02df9f1258cd0be14e793732)

In order to resolve I had to:
 - Generate master.key in vscode:
    -```EDITOR="code --wait" rails credentials:edit``` 
 - Add RAILS_MASTER_KEY to Heroku via website
    - ```heroku config:set RAILS_MASTER_KEY='cat config/master.key'```
 - Disabled node_module caching on heroku
    - ```heroku config:set NODE_MODULES_CACHE=false```  
 - Add Buildpacks to Heroku (Order Specific)
     - heroku/nodejs
         - ```heroku buildpacks:add --index 1 heroku/nodejs```
     - heroku/ruby
        - ```heroku buildpacks:add --index 2 heroku/ruby``` 
  - Uncommented 
     - ```config.require_master_key = true```

Live Branch Deployment Confirmed: [deploy-hotfix-branch-live](https://judoten.herokuapp.com/)